### PR TITLE
chore: bump version to 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.0.1] — 2026-08-05
+
+### Added
+
+- **Editable hotkeys**: the Settings → Hotkeys section is no longer read-only — 9 of the 11 app shortcuts can now be rebound (`Esc` and `F1` stay fixed). Assigning a combination that's already in use is blocked, with a hint showing which action currently owns it.
+- The in-app changelog is now shown inline in Settings → About while an update is available or downloaded, instead of only on the GitHub Releases page.
+
+### Fixed
+
+- **Jump host (ProxyJump) connections now actually work.** In 1.0.0 the setting was stored, imported, and validated, but the second SSH hop was never established on a real connection attempt — every jump-host connection silently went direct instead. The jump host is now picked from your saved hosts (not a free-text alias), "Test connection" runs the full two-hop chain, deleting a host that's used as someone's jump host warns first, and `~/.ssh/config` import resolves `ProxyJump` aliases to the matching imported host.
+- Clicking an update-available notification in the header bell now opens Settings → About; it previously dismissed the notification without navigating anywhere.
+
+### Changed
+
+- `Ctrl+L` is no longer intercepted by the app — it now reaches the shell directly and clears the screen, per the common terminal convention. The command catalog, which previously opened on `Ctrl+L`, moved to `Ctrl+Shift+L` by default.
+
 ## [1.0.0] — 2026-07-25
 
 First release of LucidSSH — a simple SSH client for Windows. Fully local: no account, no cloud, no telemetry.

--- a/docs/Data_Structures.md
+++ b/docs/Data_Structures.md
@@ -53,9 +53,8 @@ CREATE TABLE hosts (
   auth_method   TEXT    NOT NULL,            -- 'password' | 'key'
   key_path      TEXT,                        -- path to the ORIGINAL key file, not a copy (SEC-02)
   group_id      INTEGER REFERENCES groups(id) ON DELETE SET NULL,
-  proxy_jump    TEXT,                        -- host id or ProxyJump string (SSH-05)
+  proxy_jump_host_id INTEGER REFERENCES hosts(id) ON DELETE SET NULL, -- jump host, a reference to another saved host (SSH-05)
   note          TEXT,
-  color_tag     TEXT,                        -- 'red'|'orange'|'green'|'blue'|'gray'|NULL (no tag), HM-08
   guard_enabled INTEGER NOT NULL DEFAULT 1,  -- per-host guard disable (GUARD-05)
   sort_order    INTEGER NOT NULL DEFAULT 0,
   created_at    TEXT    NOT NULL,
@@ -69,7 +68,6 @@ CREATE TABLE hosts (
 
 ```ts
 type AuthMethod = 'password' | 'key';
-type HostColorTag = 'red' | 'orange' | 'green' | 'blue' | 'gray'; // HM-08
 
 interface HostGroup {
   id: number;
@@ -88,9 +86,8 @@ interface Host {
   authMethod: AuthMethod;
   keyPath?: string;        // path to the original
   groupId?: number;
-  proxyJump?: string;
+  proxyJumpHostId?: number;
   note?: string;
-  colorTag?: HostColorTag;  // HM-08, undefined/null = no tag
   guardEnabled: boolean;
   sortOrder: number;
   createdAt: string;
@@ -107,7 +104,7 @@ interface HostInput {
   authMethod: AuthMethod;
   keyPath?: string;
   groupId?: number;
-  proxyJump?: string;
+  proxyJumpHostId?: number;
   note?: string;
   guardEnabled: boolean;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lucidssh",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lucidssh",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@fontsource/inter": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lucidssh",
   "productName": "LucidSSH",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "LucidSSH for Windows — SSH-клиент с защитой от опасных команд и объяснением ошибок",
   "main": "out/main/index.js",
   "private": true,


### PR DESCRIPTION
Version bump for the 1.0.1 patch release.

## Summary
- `package.json` / `package-lock.json`: 1.0.0 → 1.0.1
- `CHANGELOG.md`: new `[1.0.1]` entry
  - **Added**: editable hotkeys (SET-10), inline changelog in Settings → About
  - **Fixed**: ProxyJump/jump host connections now actually establish the second SSH hop (SSH-05); update-notification bell now navigates to Settings → About
  - **Changed**: `Ctrl+L` no longer intercepted by the app (reaches the shell, clears screen); command catalog default moved to `Ctrl+Shift+L`
- `docs/Data_Structures.md`: fixed stale `hosts` schema (`proxy_jump` string → `proxy_jump_host_id` reference, per the SSH-05 fix) and removed the never-shipped `color_tag`/`HostColorTag` (HM-08, deferred and rolled back before 1.0)

## Verification
- `typecheck` / `lint` — clean
- `test` — 543/543 passing (33 files)
- `npm run dist` — unsigned NSIS installer built, confirmed `NotSigned` via `Get-AuthenticodeSignature` (expected, BLK-01)
- Manually verified: installed 1.0.0 → auto-update to this build → hosts preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)