### PR TITLE
fix(guard): take confirmation target from the dangerous fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **The dangerous command guard now asks you to confirm the right object.** In a compound command whose destructive part wasn't last — `rm -rf ./node_modules && npm install` — the confirmation dialog named the tail of the whole line (`install`) instead of what was actually being deleted. The guard still blocked such commands, but the name you had to type said nothing about the danger. It now takes the object from the destructive fragment itself.
+
 ## [1.0.1] — 2026-08-05
 
 ### Added

--- a/src/main/guard/manager.test.ts
+++ b/src/main/guard/manager.test.ts
@@ -467,12 +467,13 @@ describe('Страж целиком — patterns × manager (сквозные т
 
   it('инвариант 2 — опасность (analyzeCommand) проверяется раньше риска доступа (GUARD-07)', () => {
     // Составная команда: обе половины разбираются обеими функциями настоящей
-    // реализации (splitCompound). target здесь не проверяется — на составных
-    // командах его захват неверен, отдельный дефект (.scratch/guard-compound-target).
+    // реализации (splitCompound). Цель берётся из опасного фрагмента, а не с
+    // конца всей строки — иначе подтверждать пришлось бы «sshd».
     const res = submitCommand('s1', 'rm -rf /tmp/build && systemctl stop sshd');
     expect(res.status).toBe('blocked');
     if (res.status !== 'blocked') return;
     expect(res.prompt.patternId).toBe('rm-recursive');
+    expect(res.prompt.target).toBe('/tmp/build');
   });
 
   it('инвариант 3 — круг подтверждения на настоящих данных: Команда (sendCommandLine)', () => {

--- a/src/main/guard/patterns.test.ts
+++ b/src/main/guard/patterns.test.ts
@@ -28,7 +28,9 @@ describe('analyzeCommand — срабатывание (GUARD-01)', () => {
   });
 
   it('опасная часть составной команды', () => {
-    expect(analyzeCommand('cd /tmp && rm -rf ./cache')?.patternId).toBe('rm-recursive');
+    const m = analyzeCommand('cd /tmp && rm -rf ./cache');
+    expect(m?.patternId).toBe('rm-recursive');
+    expect(m?.target).toBe('./cache');
     expect(analyzeCommand('echo hi; dd if=/dev/zero of=/dev/sda')?.patternId).toBe('dd-write');
   });
 
@@ -74,6 +76,56 @@ describe('analyzeCommand — срабатывание (GUARD-01)', () => {
 
   it('kill -9 1', () => {
     expect(analyzeCommand('kill -9 1')?.patternId).toBe('kill-init');
+  });
+});
+
+/**
+ * GUARD-03: цель подтверждения — объект из опасного фрагмента, а не хвост всей
+ * строки. Регресс на дефекте, когда `rm -rf /var/www; echo done` просил набрать
+ * «done»: паттерны с якорем `$` захватывали конец строки целиком.
+ */
+describe('analyzeCommand — цель в составной команде (GUARD-03)', () => {
+  const cases: { cmd: string; target: string; confirmationText: string }[] = [
+    { cmd: 'rm -rf /var/www; echo done', target: '/var/www', confirmationText: 'www' },
+    {
+      cmd: 'rm -rf ./node_modules && npm install',
+      target: './node_modules',
+      confirmationText: 'node_modules'
+    },
+    { cmd: 'rm -rf dist && npm run build', target: 'dist', confirmationText: 'dist' },
+    {
+      cmd: 'rm -rf /tmp/cache; systemctl restart nginx',
+      target: '/tmp/cache',
+      confirmationText: 'cache'
+    },
+    { cmd: 'shred /etc/passwd; echo done', target: '/etc/passwd', confirmationText: 'passwd' },
+    { cmd: 'wipefs -a /dev/sdb && reboot', target: '/dev/sdb', confirmationText: 'sdb' },
+    {
+      cmd: 'rm -rf /tmp/build && systemctl restart sshd',
+      target: '/tmp/build',
+      confirmationText: 'build'
+    }
+  ];
+
+  for (const { cmd, target, confirmationText } of cases) {
+    it(`цель из опасного фрагмента, а не хвост строки: ${cmd}`, () => {
+      const m = analyzeCommand(cmd);
+      expect(m?.target).toBe(target);
+      expect(m?.confirmationText).toBe(confirmationText);
+      expect(m?.confirmationKind).toBe('target');
+    });
+  }
+
+  it('флаги не попадают в цель на простой команде', () => {
+    expect(analyzeCommand('wipefs -a /dev/sdb')?.target).toBe('/dev/sdb');
+    expect(analyzeCommand('shred -n 3 /dev/sdb')?.target).toBe('/dev/sdb');
+  });
+
+  it('форк-бомба распознаётся, несмотря на разбиение по | и ;', () => {
+    // Ради неё существует проход по всей строке: разбиение разрушило бы паттерн.
+    expect(analyzeCommand(':(){ :|:& };:')?.patternId).toBe('fork-bomb');
+    expect(analyzeCommand('echo hi; :(){ :|:& };:')?.patternId).toBe('fork-bomb');
+    expect(analyzeCommand('sudo :(){ :|:& };:')?.patternId).toBe('fork-bomb');
   });
 });
 

--- a/src/main/guard/patterns.ts
+++ b/src/main/guard/patterns.ts
@@ -27,6 +27,15 @@ export interface DangerMatch {
 interface GuardPattern {
   id: DangerPatternId;
   re: RegExp;
+  /**
+   * Матчить ТОЛЬКО строку целиком, не разбивая её на простые команды.
+   * Ставится паттерну, в чьём регекспе `;` `&&` `||` `|` — значащие символы:
+   * разбиение по ним разрушило бы сам паттерн (единственный такой — форк-бомба).
+   * Всем остальным флаг НЕ нужен: их матч по всей строке ломает цель — якорь `$`
+   * захватывает хвост всей строки вместо объекта опасного фрагмента (GUARD-03),
+   * и `rm -rf /var/www; echo done` просит подтвердить словом «done».
+   */
+  matchWhole?: true;
   scope: DangerScope | ((m: RegExpMatchArray) => DangerScope);
   /** Извлечение цели из совпадения; null → вся команда */
   target: (m: RegExpMatchArray) => string | null;
@@ -51,7 +60,8 @@ const CONFIRM_WORD = 'ПОДТВЕРЖДАЮ';
 
 /**
  * Паттерны применяются к каждой команде в составной строке (после разбиения
- * по ; && || |). Порядок важен: первый совпавший выигрывает.
+ * по ; && || |) — кроме помеченных `matchWhole`, которые матчатся только по
+ * строке целиком. Порядок важен: первый совпавший выигрывает.
  */
 const PATTERNS: GuardPattern[] = [
   {
@@ -112,9 +122,11 @@ const PATTERNS: GuardPattern[] = [
     target: (m) => lastToken(m[1])
   },
   {
-    // fork-бомба
+    // fork-бомба. matchWhole: содержит `|` и `;` как значащие символы —
+    // разбиение составной команды разорвало бы паттерн на части.
     id: 'fork-bomb',
     re: /:\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:/,
+    matchWhole: true,
     scope: 'other',
     target: () => null
   },
@@ -224,12 +236,14 @@ export function analyzeCommand(command: string): DangerMatch | null {
   const trimmed = command.trim();
   if (trimmed.length === 0 || trimmed.length > 10_000) return null;
 
-  // Паттерны, разрушаемые разбиением по |/; (fork-бомба) — проверяем целиком.
-  const wholeMatch = matchPatterns(trimmed);
+  // Проход 1: паттерны, разрушаемые разбиением по |/; (fork-бомба) — по всей строке.
+  const wholeMatch = matchPatterns(trimmed, WHOLE_PATTERNS);
   if (wholeMatch) return wholeMatch;
 
+  // Проход 2: все остальные — только по фрагментам, чтобы цель бралась из
+  // опасного фрагмента, а не с конца всей строки (GUARD-03).
   for (const part of splitCompound(trimmed)) {
-    const match = matchPatterns(part);
+    const match = matchPatterns(part, PART_PATTERNS);
     if (match) return match;
   }
   return null;
@@ -243,9 +257,13 @@ export function stripCmdPrefix(command: string): string {
   return command.replace(CMD_PREFIX_RE, '');
 }
 
-function matchPatterns(part: string): DangerMatch | null {
+/** Две непересекающиеся группы: каждый паттерн проверяется ровно в одном проходе. */
+const WHOLE_PATTERNS = PATTERNS.filter((p) => p.matchWhole === true);
+const PART_PATTERNS = PATTERNS.filter((p) => p.matchWhole !== true);
+
+function matchPatterns(part: string, patterns: GuardPattern[]): DangerMatch | null {
   const unprefixed = part.replace(CMD_PREFIX_RE, '');
-  for (const pattern of PATTERNS) {
+  for (const pattern of patterns) {
     const m = unprefixed.match(pattern.re) ?? part.match(pattern.re);
     if (!m) continue;
     const rawTarget = pattern.target(m);


### PR DESCRIPTION
Patterns anchored at `$` matched the whole compound line, so the target came from the tail of the string instead of the destructive fragment: `rm -rf /var/www; echo done` asked the user to type done.

Mark the only pattern that needs the whole line (fork bomb, where `|` and `;` are literal characters) with `matchWhole` and run two disjoint passes: flagged patterns over the whole string, the rest over fragments only.