### PR TITLE
fix(guard): treat single & as a compound-command separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - **The dangerous command guard now asks you to confirm the right object.** In a compound command whose destructive part wasn't last — `rm -rf ./node_modules && npm install` — the confirmation dialog named the tail of the whole line (`install`) instead of what was actually being deleted. The guard still blocked such commands, but the name you had to type said nothing about the danger. It now takes the object from the destructive fragment itself.
+- The same fix now also covers a background launch with a single `&` — `rm -rf /var/www & echo done` asked you to confirm `done` instead of `/var/www`. A redirect like `2>&1`, `&>file`, or `>&2` is correctly left alone; it's not treated as a separator.
 
 ## [1.0.1] — 2026-08-05
 

--- a/src/main/guard/patterns.test.ts
+++ b/src/main/guard/patterns.test.ts
@@ -58,6 +58,12 @@ describe('analyzeCommand — срабатывание (GUARD-01)', () => {
     expect(analyzeCommand('cat backup.img > /dev/nvme0n1')?.scope).toBe('disk');
   });
 
+  it('перенаправление в устройство без пробела (guard-background-ampersand: не съедается как хвостовой редирект)', () => {
+    expect(analyzeCommand('echo test >/dev/sda')?.patternId).toBe('redirect-device');
+    expect(analyzeCommand('echo test >>/dev/sda')?.patternId).toBe('redirect-device');
+    expect(analyzeCommand('echo hi >/dev/sda &')?.patternId).toBe('redirect-device');
+  });
+
   it('fork-бомба — подтверждение словом', () => {
     const m = analyzeCommand(':(){ :|:& };:');
     expect(m?.patternId).toBe('fork-bomb');
@@ -126,6 +132,42 @@ describe('analyzeCommand — цель в составной команде (GUAR
     expect(analyzeCommand(':(){ :|:& };:')?.patternId).toBe('fork-bomb');
     expect(analyzeCommand('echo hi; :(){ :|:& };:')?.patternId).toBe('fork-bomb');
     expect(analyzeCommand('sudo :(){ :|:& };:')?.patternId).toBe('fork-bomb');
+  });
+
+  it('форк-бомба распознаётся и после фонового `&` перед ней', () => {
+    // & внутри самой бомбы не должен помешать проходу по всей строке (matchWhole).
+    expect(analyzeCommand('echo hi & :(){ :|:& };:')?.patternId).toBe('fork-bomb');
+  });
+});
+
+describe('analyzeCommand — фоновый запуск через одиночный `&` (guard-background-ampersand)', () => {
+  it('цель берётся из опасного фрагмента, а не из хвоста после &', () => {
+    const m = analyzeCommand('rm -rf /var/www & echo done');
+    expect(m?.target).toBe('/var/www');
+    expect(m?.confirmationText).toBe('www');
+  });
+
+  it('фоновый запуск без второй команды (висячий &)', () => {
+    const m = analyzeCommand('rm -rf /var/www &');
+    expect(m?.target).toBe('/var/www');
+  });
+
+  it('несколько фоновых команд подряд', () => {
+    const m = analyzeCommand('dd if=/dev/zero of=/dev/sdb & disown');
+    expect(m?.target).toBe('/dev/sdb');
+  });
+
+  it('`&&` не распадается на пустой фрагмент из-за одиночного &', () => {
+    const m = analyzeCommand('rm -rf /var/www && echo done');
+    expect(m?.target).toBe('/var/www');
+    expect(m?.confirmationText).toBe('www');
+  });
+
+  it('& внутри перенаправления (2>&1, &>file, >&2) — не разделитель', () => {
+    expect(analyzeCommand('rm -rf /var/www 2>&1')?.target).toBe('/var/www');
+    expect(analyzeCommand('dd if=/dev/zero of=/dev/sdb 2>&1')?.target).toBe('/dev/sdb');
+    expect(analyzeCommand('rm -rf /var/www &>/dev/null')?.target).toBe('/var/www');
+    expect(analyzeCommand('rm -rf /var/www >&2')?.target).toBe('/var/www');
   });
 });
 
@@ -303,6 +345,10 @@ describe('analyzeAccessRisk — служба sshd', () => {
       expect(analyzeAccessRisk(cmd)).toBeNull();
     });
   }
+
+  it('распознаётся и за одиночным & (guard-background-ampersand)', () => {
+    expect(analyzeAccessRisk('systemctl stop sshd & echo ok')?.riskId).toBe('sshd-service');
+  });
 });
 
 describe('analyzeAccessRisk — общее поведение', () => {

--- a/src/main/guard/patterns.ts
+++ b/src/main/guard/patterns.ts
@@ -41,10 +41,29 @@ interface GuardPattern {
   target: (m: RegExpMatchArray) => string | null;
 }
 
-/** Последний токен строки аргументов (цель команд вида shred/wipefs). */
+/** Хвостовое перенаправление без пробела внутри токена: `2>&1`, `>&2`, `&>file`, `&>>file`,
+ *  `>file`, `2>>file`. Требует пробела ПЕРЕД собой — не трогает слитные случаи вроде
+ *  `/var/www2>&1` (консервативно: как и с кавычками, не пытаемся разобрать всё).
+ *  Применяется только при извлечении цели (rm/shred/wipefs) — НЕ к фрагменту, который
+ *  матчат сами паттерны: `redirect-device` (`echo x >/dev/sda`) как раз ищет `>` + путь,
+ *  и снимать редирект до его проверки — значит спрятать от Стража ровно то, что он ищет. */
+const TRAILING_REDIRECT_RE = /\s+(?:\d*>{1,2}&\d+|&>{1,2}\S*|\d*>{1,2}\S+)$/;
+
+/** Снять один или несколько хвостовых редиректов подряд (`cmd > out.log 2>&1`). */
+function stripTrailingRedirects(s: string): string {
+  let result = s;
+  for (let next = result.replace(TRAILING_REDIRECT_RE, ''); next !== result; ) {
+    result = next;
+    next = result.replace(TRAILING_REDIRECT_RE, '');
+  }
+  return result;
+}
+
+/** Последний токен строки аргументов (цель команд вида shred/wipefs). Хвостовой
+ *  редирект снимается до разбиения на токены — иначе целью станет `2>&1`, а не файл. */
 function lastToken(args: string | undefined): string | null {
   if (!args) return null;
-  const tokens = args.trim().split(/\s+/);
+  const tokens = stripTrailingRedirects(args.trim()).trim().split(/\s+/);
   const last = tokens[tokens.length - 1];
   return last && !last.startsWith('-') ? last : null;
 }
@@ -66,8 +85,13 @@ const CONFIRM_WORD = 'ПОДТВЕРЖДАЮ';
 const PATTERNS: GuardPattern[] = [
   {
     // rm с рекурсивным или форсированным флагом: rm -rf X, rm -r X, rm --recursive X
+    // Хвост вида `2>&1`/`>file` после цели опционально поглощается без захвата —
+    // иначе им же и подтверждали бы удаление (см. TRAILING_REDIRECT_RE выше).
     id: 'rm-recursive',
-    re: /(?:^|\s)rm\s+(?=[^\n]*(?:-[a-zA-Z]*[rR][a-zA-Z]*|--recursive))[^\n]*?\s(?!-)(\S+)\s*$/,
+    re: new RegExp(
+      String.raw`(?:^|\s)rm\s+(?=[^\n]*(?:-[a-zA-Z]*[rR][a-zA-Z]*|--recursive))[^\n]*?\s(?!-)(\S+)` +
+        String.raw`(?:\s+(?:\d*>{1,2}&\d+|&>{1,2}\S*|\d*>{1,2}\S+))*\s*$`
+    ),
     scope: (m) => (m[1] === '/' || m[1] === '/*' ? 'disk' : 'directory'),
     target: (m) => m[1] ?? null
   },
@@ -219,11 +243,19 @@ export function analyzeAccessRisk(command: string): AccessRiskMatch | null {
   return null;
 }
 
-/** Разбиение составной команды на простые (; && || |) без учёта кавычек — консервативно.
+/** Разбиение составной команды на простые (; && || | &) без учёта кавычек — консервативно.
+ *  Одиночный `&` (фоновый запуск) — разделитель наравне с `;`/`&&`/`||`/`|`; `&&` матчится
+ *  раньше него в альтернативе, иначе `a && b` распалось бы на `a`, «», `b`. Лукэраунды
+ *  исключают `&`, склеенный с `>` (`2>&1`, `&>file`, `>&2`) — там `&` часть перенаправления,
+ *  не разделитель. Фрагмент отдаётся паттернам как есть, вместе с редиректом: его снятие —
+ *  забота точки извлечения цели (rm-recursive, lastToken), а не этой функции — `redirect-device`
+ *  как раз матчит `>`+путь, и снимать его здесь означало бы прятать цель от самого Стража
+ *  (см. spec .scratch/guard-background-ampersand). Кавычки по-прежнему не учитываются —
+ *  осознанное упрощение.
  *  Экспорт: переиспользуется детекцией эскалации шелла (shellIntegration.ts). */
 export function splitCompound(command: string): string[] {
   return command
-    .split(/;|&&|\|\||\|/)
+    .split(/;|&&|\|\||\||(?<!>)&(?!>)/)
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
 }

--- a/src/main/ssh/shellIntegration.test.ts
+++ b/src/main/ssh/shellIntegration.test.ts
@@ -293,7 +293,8 @@ describe('isShellEscalationCommand — команды, сменяющие про
     '/bin/bash',
     'exec su -',
     'doas -s',
-    'cd /tmp && sudo -i'
+    'cd /tmp && sudo -i',
+    'long_task & sudo -i' // guard-background-ampersand: & тоже разделитель
   ])('эскалация: %s', (cmd) => {
     expect(isShellEscalationCommand(cmd)).toBe(true);
   });
@@ -308,7 +309,8 @@ describe('isShellEscalationCommand — команды, сменяющие про
     'ls -la',
     'suspend',
     'echo su',
-    'cat /etc/sudoers'
+    'cat /etc/sudoers',
+    'echo hi 2>&1' // guard-background-ampersand: редирект — не разделитель, не эскалация
   ])('не эскалация: %s', (cmd) => {
     expect(isShellEscalationCommand(cmd)).toBe(false);
   });
@@ -327,7 +329,8 @@ describe('detectInteractiveProgram (BRD-05) — запуск известной 
     ['sudo htop', 'htop'],
     ['cd /var && less log', 'less'],
     ['cd /var; htop', 'htop'],
-    ['/usr/bin/vim file', 'vim']
+    ['/usr/bin/vim file', 'vim'],
+    ['long_task & htop', 'htop'] // guard-background-ampersand: & тоже разделитель
   ] as const)('%s → %s', (cmd, expected) => {
     expect(detectInteractiveProgram(cmd)).toBe(expected);
   });
@@ -338,7 +341,8 @@ describe('detectInteractiveProgram (BRD-05) — запуск известной 
     'echo top',
     'topless', // не должно матчиться как отдельное слово 'top'
     'nginx',
-    'sudo apt update'
+    'sudo apt update',
+    'echo hi 2>&1' // guard-background-ampersand: редирект — не разделитель
   ])('не интерактивная программа: %s', (cmd) => {
     expect(detectInteractiveProgram(cmd)).toBeNull();
   });


### PR DESCRIPTION
## Что чинит

`splitCompound` (`guard/patterns.ts`) резал строку по `;`, `&&`, `||`, `|`, но не по одиночному `&` (фоновый запуск). Из-за этого цель подтверждения в Страже уезжала в хвост всей строки:

```
rm -rf /var/www & echo done   →   было: target = "done"
                               →   стало: target = "/var/www"
```

Тот же класс дефекта, что чинил #15 (`guard-compound-target`), только через другую дырку: там разбиение работало, но паттерны матчились по всей строке; здесь паттерны матчатся правильно, но разбиения не происходит — разделитель не опознан.

Заодно чинится `analyzeAccessRisk` (GUARD-07): `systemctl stop sshd & echo ok` теперь тоже распознаётся.

## Как

Правится сама `splitCompound` (вариант А из спеки — один разделитель на всех потребителей, включая `shellIntegration.ts`), а не отдельный набор разделителей только для Стража.

- `&` добавлен в альтернативу разделителей, после `&&` (иначе `a && b` распалось бы на `a`, «», `b`).
- Лукэраунды исключают `&`, склеенный с `>` (`2>&1`, `&>file`, `>&2`) — там `&` часть перенаправления, не разделитель.
- Отдельно (`stripTrailingRedirects`) с хвоста фрагмента снимается сам редирект — иначе цель у `rm`/`shred`/`wipefs` захватывалась бы из `2>&1`, а не из объекта команды.

## Проверено

- `npm run typecheck`, `npm run lint`, полный прогон тестов (573/573, включая ABI-цикл `rebuild:test`/`rebuild:app`) — зелёные.
- `ssh/shellIntegration.test.ts` зелёный без изменения ожиданий.
- Ручная проверка в приложении: `rm -rf /var/www & echo done` на одноразовом Docker SSH-хосте — модалка просит подтвердить `www`, не `done`.

Спека: `.scratch/guard-background-ampersand/spec.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)