### PR TITLE
docs: sync guard IPC prompt schema with src/shared/guard.ts

### DIFF
--- a/docs/Data_Structures.md
+++ b/docs/Data_Structures.md
@@ -504,7 +504,6 @@ interface LucidSSHBridge {
   onError(cb: (sessionId: string, explanation: ErrorExplanation) => void): () => void;
   onDashboard(cb: (sessionId: string, metrics: DashboardMetrics) => void): () => void;
   onBreadcrumb(cb: (sessionId: string, crumb: Breadcrumb) => void): () => void;
-  onNotification(cb: (event: AppNotification) => void): () => void; // NOTIF-03: fingerprint + update
 }
 ```
 
@@ -568,6 +567,20 @@ type SubmitResult =
   | { status: 'sent' }
   | { status: 'blocked'; prompt: DangerousCommandPrompt }
   | { status: 'access-risk'; prompt: AccessRiskPrompt };
+
+// The header events feed (NOTIF-03) is assembled in the renderer and never crosses
+// IPC: there is no notification channel. Held in memory by stores/events.tsx (these
+// are active alerts, not history) and fed by three signals that already exist —
+// onHostKeyPrompt with isChanged (fingerprint), onUpdateStatus with state
+// 'available' (update), and the renderer's own shell-state signal (guardUncertain,
+// TERM-10 fail-safe).
+interface AppEvent {
+  id: string;
+  type: 'fingerprint' | 'update' | 'guardUncertain';
+  hostName?: string;           // fingerprint, guardUncertain
+  version?: string;            // update
+  createdAt: number;
+}
 
 interface DashboardMetrics {
   cpuPercent: number | null;   // null → "—" (DASH-05)

--- a/docs/Data_Structures.md
+++ b/docs/Data_Structures.md
@@ -449,9 +449,16 @@ interface LucidSSHBridge {
   // --- Sessions ---
   connectHost(hostId: number): Promise<{ sessionId: string; status: SessionStatus }>;
   disconnectSession(sessionId: string): Promise<void>;
-  sendTerminalInput(sessionId: string, text: string): Promise<void>;
   confirmHostKey(requestId: string, decision: 'accept' | 'reject'): Promise<void>;
+
+  // --- Guard (a command reaches the server only through this check, ADR-0008) ---
+  // Both entry points return SubmitResult: 'sent' — it went out; 'blocked' — the
+  // type-to-confirm dialog (GUARD-02); 'access-risk' — the advisory dialog (GUARD-07).
+  // The prompt comes back as the reply to the call itself; there is no separate event.
+  submitCommand(sessionId: string, command: string): Promise<SubmitResult>;   // Enter-submitted input
+  sendTerminalInput(sessionId: string, text: string): Promise<SubmitResult>;  // raw text (paste)
   confirmDangerousCommand(requestId: string, confirmationText: string): Promise<{ allowed: boolean }>;
+  cancelDangerousCommand(requestId: string): void;       // cancel: the pending record is dropped in main
 
   // --- Catalog / errors (read-only access to the built-in databases) ---
   getCommandCatalog(): Promise<CommandsDatabase>;
@@ -490,14 +497,14 @@ interface LucidSSHBridge {
   applyUpdate(): Promise<void>;                           // after confirmation
 
   // --- Events (main → renderer) ---
-  onTerminalData(cb: (sessionId: string, data: string) => void): void;
-  onSessionStatus(cb: (sessionId: string, status: SessionStatus) => void): void;
-  onHostKeyPrompt(cb: (req: HostKeyPrompt) => void): void;
-  onDangerousCommand(cb: (req: DangerousCommandPrompt) => void): void;
-  onError(cb: (sessionId: string, explanation: ErrorExplanation) => void): void;
-  onDashboard(cb: (sessionId: string, metrics: DashboardMetrics) => void): void;
-  onBreadcrumb(cb: (sessionId: string, crumb: Breadcrumb) => void): void;
-  onNotification(cb: (event: AppNotification) => void): void; // NOTIF-03: fingerprint + update
+  // Every subscription returns its own unsubscribe function (called on unmount).
+  onTerminalData(cb: (sessionId: string, data: string) => void): () => void;
+  onSessionStatus(cb: (sessionId: string, status: SessionStatus) => void): () => void;
+  onHostKeyPrompt(cb: (req: HostKeyPrompt) => void): () => void;
+  onError(cb: (sessionId: string, explanation: ErrorExplanation) => void): () => void;
+  onDashboard(cb: (sessionId: string, metrics: DashboardMetrics) => void): () => void;
+  onBreadcrumb(cb: (sessionId: string, crumb: Breadcrumb) => void): () => void;
+  onNotification(cb: (event: AppNotification) => void): () => void; // NOTIF-03: fingerprint + update
 }
 ```
 
@@ -514,14 +521,53 @@ interface HostKeyPrompt {
   previousFingerprint?: string;
 }
 
+type DangerScope = 'file' | 'directory' | 'disk' | 'other';
+
+// Id of a dangerous pattern (guard/patterns.ts, GUARD-01) — the i18n key of its
+// explanation (guard.explain.<id>) and what the renderer compares against. The
+// union is closed: a new pattern that is not listed here fails to compile.
+type DangerPatternId =
+  | 'rm-recursive' | 'dd-write' | 'mkfs' | 'chmod-777' | 'truncate'
+  | 'redirect-device' | 'shred' | 'wipefs' | 'fork-bomb'
+  | 'drop-database' | 'kill-init';
+
 interface DangerousCommandPrompt {
   requestId: string;
   sessionId: string;
   command: string;
-  target: string;              // the real path/object (GUARD-03)
-  scope: 'file' | 'directory' | 'disk' | 'other';
-  explanation: string;
+  patternId: DangerPatternId;  // pattern of the CHOSEN object — the explanation describes that one
+  // The object whose name must be typed (GUARD-03). When a compound command has
+  // several dangerous fragments, it is drawn at random among the heaviest ones
+  // ('disk' outranks everything, the rest are level); the draw happens once in
+  // main and is not re-rolled when the user retypes after a typo.
+  target: string;
+  // ALL recognized objects of the command — for display only: the whole-string
+  // match first (fork bomb), then per-fragment matches in fragment order. Always
+  // contains target; with a single dangerous fragment it is exactly that one.
+  targets: string[];
+  scope: DangerScope;          // scope of the CHOSEN object
+  confirmationKind: 'target' | 'word'; // by the object's name, or by a generic confirmation word
+  confirmationText: string;    // what exactly to type, already localized; compared in main
 }
+
+// Category of the risk of losing SSH access (GUARD-07).
+type AccessRiskId = 'sshd-config' | 'firewall' | 'passwd' | 'sshd-service';
+
+// Warning about the risk of losing SSH access (GUARD-07): advisory, not a block —
+// a two-button dialog with no type-to-confirm. Only checked when no dangerous
+// pattern matched the command.
+interface AccessRiskPrompt {
+  requestId: string;
+  sessionId: string;
+  command: string;
+  riskId: AccessRiskId;        // the text comes from i18n keyed by riskId, it is not sent as a string
+}
+
+// Result of submitting a command through the guard (submitCommand / sendTerminalInput).
+type SubmitResult =
+  | { status: 'sent' }
+  | { status: 'blocked'; prompt: DangerousCommandPrompt }
+  | { status: 'access-risk'; prompt: AccessRiskPrompt };
 
 interface DashboardMetrics {
   cpuPercent: number | null;   // null → "—" (DASH-05)


### PR DESCRIPTION
Documentation only — no code changes.

`docs/Data_Structures.md` §7.1 described a guard IPC contract that the app stopped honouring a while ago. Spotted during the review of #17, which widened the drift by adding one more field.

## What was wrong

**`DangerousCommandPrompt`** carried an `explanation: string` the main process never sends, and was missing everything the renderer actually reads: `patternId`, `targets`, `confirmationKind`, `confirmationText`.

**GUARD-07 was undocumented.** `AccessRiskPrompt` did not appear at all, so the shapes it depends on (`SubmitResult`, `AccessRiskId`) were absent too. `DangerScope` and `DangerPatternId` are now written out instead of being inlined by hand.

**The delivery path was wrong.** The document showed the prompt arriving through an `onDangerousCommand` event; there is no such event in the bridge. Both guard entry points return the prompt as the reply to the call itself:

- `submitCommand(sessionId, command): Promise<SubmitResult>` — input submitted with Enter
- `sendTerminalInput(sessionId, text): Promise<SubmitResult>` — raw text (paste)

`cancelDangerousCommand` was missing from the contract entirely.

**Event subscriptions.** Every `onX` in the preload bridge returns its own unsubscribe function; the document said `void` for all seven.

**`onNotification` did not exist.** The bridge listed `onNotification(cb: (event: AppNotification) => void)` for NOTIF-03; neither name appears anywhere in `src/`. The header events feed is assembled in the renderer and never crosses IPC, so the document now describes what is actually there — `AppEvent`, held in memory by `stores/events.tsx`, rendered by `chrome/EventsMenu.tsx`, and fed by three signals that already exist:

| source | event type |
| --- | --- |
| `onHostKeyPrompt` with `isChanged` | `fingerprint` |
| `onUpdateStatus` with `state === 'available'` | `update` |
| the renderer's own shell-state signal (TERM-10 fail-safe) | `guardUncertain` |

The stale line predated the third type — its comment promised "fingerprint + update" only. It is unrelated to `main/notifications/notifier.ts`, which serves NOTIF-01/02/04 (Windows toasts).

## Verification

Each line was checked against `src/preload/index.ts`, `src/shared/guard.ts` and the renderer stores rather than reconstructed from memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)