### PR TITLE
refactor(guard,ipc): narrow session access to sessionExists/hostIdOf

### DIFF
--- a/src/main/guard/manager.test.ts
+++ b/src/main/guard/manager.test.ts
@@ -2,7 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DangerPatternId, DangerScope } from '@shared/guard';
 
 vi.mock('../ssh/sessionManager', () => ({
-  getSession: vi.fn(),
+  sessionExists: vi.fn(),
+  hostIdOf: vi.fn(),
   recordBlockedCommand: vi.fn(),
   sendCommandLine: vi.fn(),
   sendInput: vi.fn()
@@ -12,7 +13,7 @@ vi.mock('../config/store', () => ({ loadConfig: vi.fn() }));
 vi.mock('./patterns', () => ({ analyzeDangers: vi.fn(), analyzeAccessRisk: vi.fn() }));
 vi.mock('../i18n', () => ({ t: vi.fn((key: string) => key) }));
 
-import { getSession, recordBlockedCommand, sendCommandLine, sendInput } from '../ssh/sessionManager';
+import { hostIdOf, recordBlockedCommand, sendCommandLine, sendInput, sessionExists } from '../ssh/sessionManager';
 import { getHost } from '../hosts/repository';
 import { loadConfig } from '../config/store';
 import type { DangerMatch } from './patterns';
@@ -25,7 +26,8 @@ import {
   cancelDangerousCommand
 } from './manager';
 
-const mockGetSession = vi.mocked(getSession);
+const mockSessionExists = vi.mocked(sessionExists);
+const mockHostIdOf = vi.mocked(hostIdOf);
 const mockRecordBlockedCommand = vi.mocked(recordBlockedCommand);
 const mockSendCommandLine = vi.mocked(sendCommandLine);
 const mockSendInput = vi.mocked(sendInput);
@@ -35,11 +37,14 @@ const mockAnalyzeDangers = vi.mocked(analyzeDangers);
 const mockAnalyzeAccessRisk = vi.mocked(analyzeAccessRisk);
 const mockT = vi.mocked(t);
 
-// ManagedSession/Host/AppConfig не экспортированы из своих модулей (по дизайну) —
-// в тестах нужны только использованные manager.ts поля, остальное подделываем
-// через unknown-каст (не any — тот запрещён линтером).
-const fakeSession = (hostId: number): ReturnType<typeof getSession> =>
-  ({ hostId }) as unknown as ReturnType<typeof getSession>;
+// Host/AppConfig не экспортированы из своих модулей (по дизайну) — в тестах
+// нужны только использованные manager.ts поля, остальное подделываем через
+// unknown-каст (не any — тот запрещён линтером).
+/** Живая сессия хоста hostId: sessionExists → true, hostIdOf → hostId. */
+function fakeSession(hostId: number): void {
+  mockSessionExists.mockReturnValue(true);
+  mockHostIdOf.mockReturnValue(hostId);
+}
 const fakeHost = (guardEnabled: boolean): ReturnType<typeof getHost> =>
   ({ guardEnabled }) as unknown as ReturnType<typeof getHost>;
 const fakeConfig = (globalEnabled: boolean): ReturnType<typeof loadConfig> =>
@@ -54,14 +59,14 @@ describe('submitCommand', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockLoadConfig.mockReturnValue(fakeConfig(true));
-    mockGetSession.mockReturnValue(fakeSession(1));
+    fakeSession(1);
     mockGetHost.mockReturnValue(fakeHost(true));
     mockAnalyzeDangers.mockReturnValue([]);
     mockAnalyzeAccessRisk.mockReturnValue(null);
   });
 
   it('неизвестная сессия — команда не отправляется', () => {
-    mockGetSession.mockReturnValue(undefined);
+    mockSessionExists.mockReturnValue(false);
     const res = submitCommand('s1', 'ls');
     expect(res).toEqual({ status: 'sent' });
     expect(mockSendCommandLine).not.toHaveBeenCalled();
@@ -101,7 +106,7 @@ describe('submitCommand', () => {
   });
 
   it('hostId=0 (Quick Connect, HM-11) — getHost(0)=null, Страж включён по умолчанию', () => {
-    mockGetSession.mockReturnValue(fakeSession(0));
+    fakeSession(0);
     mockGetHost.mockReturnValue(null);
     mockAnalyzeDangers.mockReturnValue([{
       patternId: 'rm-recursive',
@@ -181,7 +186,7 @@ describe('submitCommand — несколько опасных фрагменто
   beforeEach(() => {
     vi.clearAllMocks();
     mockLoadConfig.mockReturnValue(fakeConfig(true));
-    mockGetSession.mockReturnValue(fakeSession(1));
+    fakeSession(1);
     mockGetHost.mockReturnValue(fakeHost(true));
     mockT.mockImplementation((key: string) => key);
     mockAnalyzeAccessRisk.mockReturnValue(null);
@@ -340,7 +345,7 @@ describe('submitRawInput', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockLoadConfig.mockReturnValue(fakeConfig(true));
-    mockGetSession.mockReturnValue(fakeSession(1));
+    fakeSession(1);
     mockGetHost.mockReturnValue(fakeHost(true));
     mockAnalyzeDangers.mockReturnValue([]);
     mockAnalyzeAccessRisk.mockReturnValue(null);
@@ -378,7 +383,7 @@ describe('submitRawInput', () => {
   });
 
   it('неизвестная сессия — данные не отправляются', () => {
-    mockGetSession.mockReturnValue(undefined);
+    mockSessionExists.mockReturnValue(false);
     const res = submitRawInput('s1', 'rm -rf /var/www');
     expect(res).toEqual({ status: 'sent' });
     expect(mockSendInput).not.toHaveBeenCalled();
@@ -403,7 +408,7 @@ describe('confirmDangerousCommand', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockLoadConfig.mockReturnValue(fakeConfig(true));
-    mockGetSession.mockReturnValue(fakeSession(1));
+    fakeSession(1);
     mockGetHost.mockReturnValue(fakeHost(true));
   });
 
@@ -473,7 +478,7 @@ describe('cancelDangerousCommand', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockLoadConfig.mockReturnValue(fakeConfig(true));
-    mockGetSession.mockReturnValue(fakeSession(1));
+    fakeSession(1);
     mockGetHost.mockReturnValue(fakeHost(true));
   });
 
@@ -524,7 +529,7 @@ describe('GUARD-07 — риск потери SSH-доступа', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockLoadConfig.mockReturnValue(fakeConfig(true));
-    mockGetSession.mockReturnValue(fakeSession(1));
+    fakeSession(1);
     mockGetHost.mockReturnValue(fakeHost(true));
     mockAnalyzeDangers.mockReturnValue([]);
     mockAnalyzeAccessRisk.mockReturnValue({ riskId: 'sshd-service' });
@@ -623,7 +628,7 @@ describe('Страж целиком — patterns × manager (сквозные т
   beforeEach(async () => {
     vi.clearAllMocks();
     mockLoadConfig.mockReturnValue(fakeConfig(true));
-    mockGetSession.mockReturnValue(fakeSession(1));
+    fakeSession(1);
     mockGetHost.mockReturnValue(fakeHost(true));
     // clearAllMocks не сбрасывает implementation, выставленную в другом describe —
     // фиксируем поведение мока i18n явно, чтобы блок не зависел от порядка тестов.

--- a/src/main/guard/manager.ts
+++ b/src/main/guard/manager.ts
@@ -3,10 +3,11 @@ import type { AccessRiskPrompt, DangerousCommandPrompt, SubmitResult } from '@sh
 import { getHost } from '../hosts/repository';
 import { loadConfig } from '../config/store';
 import {
-  getSession,
+  hostIdOf,
   recordBlockedCommand,
   sendCommandLine,
-  sendInput
+  sendInput,
+  sessionExists
 } from '../ssh/sessionManager';
 import type { DangerMatch } from './patterns';
 import { analyzeAccessRisk, analyzeDangers } from './patterns';
@@ -43,9 +44,9 @@ const pending = new Map<string, Pending>();
 /** Активен ли Страж для сессии: глобально И для конкретного хоста (GUARD-05). */
 function guardEnabledFor(sessionId: string): boolean {
   if (!loadConfig().guard.globalEnabled) return false;
-  const session = getSession(sessionId);
-  if (!session) return true;
-  const host = getHost(session.hostId);
+  const hostId = hostIdOf(sessionId);
+  if (hostId === undefined) return true;
+  const host = getHost(hostId);
   return host ? host.guardEnabled : true;
 }
 
@@ -55,8 +56,7 @@ function guardEnabledFor(sessionId: string): boolean {
  * Иначе команда отправляется с переводом строки.
  */
 export function submitCommand(sessionId: string, command: string): SubmitResult {
-  const session = getSession(sessionId);
-  if (!session) return { status: 'sent' }; // неизвестная сессия — IPC-слой уже отверг
+  if (!sessionExists(sessionId)) return { status: 'sent' }; // неизвестная сессия — IPC-слой уже отверг
 
   if (guardEnabledFor(sessionId)) {
     const danger = dangerPrompt(sessionId, command, 'command');
@@ -167,8 +167,7 @@ function riskPrompt(
  * текст, летящий в интерактивную программу).
  */
 export function submitRawInput(sessionId: string, data: string): SubmitResult {
-  const session = getSession(sessionId);
-  if (!session) return { status: 'sent' }; // неизвестная сессия — sendInput сам no-op
+  if (!sessionExists(sessionId)) return { status: 'sent' }; // неизвестная сессия — sendInput сам no-op
 
   if (data.length >= RAW_CHECK_THRESHOLD && guardEnabledFor(sessionId)) {
     const danger = dangerPrompt(sessionId, data, 'raw');

--- a/src/main/ipc/sessions.ts
+++ b/src/main/ipc/sessions.ts
@@ -9,10 +9,10 @@ import {
   connectQuickHost,
   destroySession,
   disconnectSession,
-  getSession,
   getSessionLog,
   listSessions,
-  resizeSession
+  resizeSession,
+  sessionExists
 } from '../ssh/sessionManager';
 import {
   cancelDangerousCommand,
@@ -40,7 +40,7 @@ function assertSessionIdFormat(v: unknown): string {
 
 function validateSessionId(v: unknown): string {
   const id = assertSessionIdFormat(v);
-  if (!getSession(id)) throw new IpcValidationError('sessionId: unknown');
+  if (!sessionExists(id)) throw new IpcValidationError('sessionId: unknown');
   return id;
 }
 
@@ -120,7 +120,7 @@ export function registerSessionIpcHandlers(): void {
       if (!Number.isInteger(cols) || !Number.isInteger(rows) || cols < 1 || cols > 1000 || rows < 1 || rows > 1000) {
         throw new IpcValidationError('size: invalid');
       }
-      if (!getSession(id)) return;
+      if (!sessionExists(id)) return;
       resizeSession(id, cols, rows);
     }
   );

--- a/src/main/ssh/sessionManager.test.ts
+++ b/src/main/ssh/sessionManager.test.ts
@@ -34,7 +34,7 @@ vi.mock('../history/repository', () => ({ recordHistory: vi.fn() }));
 vi.mock('../notifications/notifier', () => ({ notifyDisconnect: vi.fn(), notifyCommandDone: vi.fn() }));
 
 import { IPC } from '@shared/ipc';
-import type { HostKeyPrompt } from '@shared/ssh';
+import type { HostKeyPrompt, SessionStatus } from '@shared/ssh';
 import { loadConfig } from '../config/store';
 import { startDashboard } from './dashboard';
 import { getMainWindow } from '../window/mainWindow';
@@ -49,6 +49,8 @@ import {
   confirmHostKey,
   destroySession,
   getSession,
+  getSessionLog,
+  listSessions,
   resizeSession,
   sendCommandLine,
   __setClientFactoryForTest,
@@ -367,14 +369,16 @@ describe('подключение через jump-хост (SSH-05)', () => {
     return connectCalls(hop)[call]?.[0] as Record<string, unknown>;
   }
 
+  const statusOf = (sessionId: string): SessionStatus | undefined =>
+    listSessions().find((s) => s.sessionId === sessionId)?.status;
+
   async function waitForDisconnected(sessionId: string): Promise<void> {
     await vi.waitFor(() => {
-      if (getSession(sessionId)?.status !== 'disconnected') throw new Error('сессия ещё не закрыта');
+      if (statusOf(sessionId) !== 'disconnected') throw new Error('сессия ещё не закрыта');
     });
   }
 
-  const logOf = (sessionId: string): Array<{ messageKey: string; step?: string }> =>
-    getSession(sessionId)?.log ?? [];
+  const logOf = (sessionId: string): Array<{ messageKey: string; step?: string }> => getSessionLog(sessionId);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -416,7 +420,7 @@ describe('подключение через jump-хост (SSH-05)', () => {
     expect(destConfig['host']).toBe('10.0.0.5');
 
     dest.emit('ready');
-    expect(getSession(sessionId)?.status).toBe('connected');
+    expect(statusOf(sessionId)).toBe('connected');
     // Shell и дашборд открываются только на целевом хосте.
     expect(mockStartDashboard).toHaveBeenCalledTimes(1);
     expect(jump.client.shell).not.toHaveBeenCalled();
@@ -503,10 +507,10 @@ describe('подключение через jump-хост (SSH-05)', () => {
       jump1.emit('ready');
       await waitForConnect(dest1);
       dest1.emit('ready');
-      expect(getSession(sessionId)?.status).toBe('connected');
+      expect(statusOf(sessionId)).toBe('connected');
 
       dest1.emit('close'); // сервер разорвал соединение
-      expect(getSession(sessionId)?.status).toBe('reconnecting');
+      expect(statusOf(sessionId)).toBe('reconnecting');
 
       await vi.advanceTimersByTimeAsync(3000);
       // Переподключение поднимает первый хоп заново — новым соединением, а
@@ -674,7 +678,10 @@ describe('resizeSession — гейтинг PTY-resize по cols (issue 11 / ADR-
   /** Доводит сессию до состояния «первый маркер уже виден» (аналог warmUp()
    *  из shellIntegrationSession.test.ts) — без этого detectInteractiveProgram
    *  не срабатывает (firstMarkSeen должен быть true). tick() зовётся напрямую
-   *  на боксе, а не через реальный setTimeout — сама коробка не имеет рук. */
+   *  на боксе, а не через реальный setTimeout — сама коробка не имеет рук.
+   *  Единственное оставшееся использование getSession в этом файле — доступа
+   *  к shellIntegration нет ни через один публичный экспорт до выноса
+   *  ShellChannel (.scratch/shell-channel-extraction/issues/03). */
   function warmUp(sessionId: string, feedData: (chunk: string) => void): void {
     feedData('Welcome to Ubuntu 24.04\r\n');
     getSession(sessionId)?.shellIntegration?.tick('setup-silence');

--- a/src/main/ssh/sessionManager.ts
+++ b/src/main/ssh/sessionManager.ts
@@ -165,6 +165,22 @@ function log(
   send(IPC.evConnectionLog, s.id, entry);
 }
 
+export function sessionExists(sessionId: string): boolean {
+  return sessions.has(sessionId);
+}
+
+export function hostIdOf(sessionId: string): number | undefined {
+  return sessions.get(sessionId)?.hostId;
+}
+
+/**
+ * @deprecated Боевых вызывающих больше нет (`sessionExists`/`hostIdOf` их
+ * заменили, .scratch/shell-channel-extraction/issues/01). Единственный
+ * оставшийся потребитель — sessionManager.test.ts:680, который дёргает
+ * `shellIntegration.tick(...)` внутри PTY-resize гейтинга; этот доступ уходит
+ * вместе с выносом ShellChannel (issue 03, spec.md «Часть 3»), только тогда
+ * getSession перестаёт экспортироваться.
+ */
 export function getSession(sessionId: string): ManagedSession | undefined {
   return sessions.get(sessionId);
 }


### PR DESCRIPTION
getSession leaked the full ManagedSession across the module boundary for callers that only checked existence or read hostId. guard/manager.ts and ipc/sessions.ts now use sessionExists()/hostIdOf() instead; the hostId check is strict === undefined so Quick Connect (hostId=0) isn't broken by !hostId.

getSession stays exported (@deprecated) — sessionManager.test.ts still reaches shellIntegration.tick() through it for PTY-resize gating tests; that access disappears once ShellChannel is extracted (issue 03).