### PR TITLE
feat: add escStack singleton and useEscapeClose hook (PR-1)

### DIFF
--- a/src/renderer/src/hooks/useEscapeClose.ts
+++ b/src/renderer/src/hooks/useEscapeClose.ts
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from 'react';
+import { pushEscHandler } from '../stores/escStack';
+
+/**
+ * Тонкая обвязка над `escStack` (ADR-0010): регистрирует вход стека на
+ * монтировании (или на переходе `enabled` в `true`) и снимает его на
+ * размонтировании / переходе обратно. `onEscape` держится в ref — обновление
+ * колбэка между рендерами не должно перерегистрировать вход, иначе он бы
+ * переставлялся на вершину стека и забирал чужой Esc.
+ */
+export function useEscapeClose(id: string, onEscape: () => void, enabled = true): void {
+  const onEscapeRef = useRef(onEscape);
+  onEscapeRef.current = onEscape;
+
+  useEffect(() => {
+    if (!enabled) return;
+    return pushEscHandler(id, () => onEscapeRef.current());
+    // onEscape намеренно не в зависимостях — актуальная версия читается из ref,
+    // регистрация не должна дёргаться на каждый рендер (см. escStack.ts).
+  }, [id, enabled]);
+}

--- a/src/renderer/src/stores/escStack.test.ts
+++ b/src/renderer/src/stores/escStack.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { __resetEscStackForTest, __setEscTargetForTest, pushEscHandler, type KeyboardEventLike } from './escStack';
+
+/**
+ * Один стек закрытия по Esc (ADR-0010, `.scratch/esc-close-stack/spec.md`).
+ * Фальшивая цель эмулирует `window`: захватывает слушатель `keydown` на фазе
+ * capture и позволяет проверить его установку/снятие напрямую. Сигнатуры
+ * `addEventListener`/`removeEventListener` намеренно требуют `{ capture: true }`
+ * третьим аргументом — так же, как реальный `EscTarget` в `escStack.ts` — чтобы
+ * смену фазы слушателя ловил typecheck, а не только ручной просмотр.
+ */
+
+type Listener = (event: KeyboardEventLike) => void;
+
+function createFakeTarget() {
+  const listeners = new Set<Listener>();
+  return {
+    addEventListener: vi.fn((_type: 'keydown', listener: Listener, options: { capture: true }) => {
+      expect(options).toEqual({ capture: true });
+      listeners.add(listener);
+    }),
+    removeEventListener: vi.fn((_type: 'keydown', listener: Listener, options: { capture: true }) => {
+      expect(options).toEqual({ capture: true });
+      listeners.delete(listener);
+    }),
+    dispatch(key: string, repeat = false): KeyboardEventLike {
+      const event: KeyboardEventLike = {
+        key,
+        repeat,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn()
+      };
+      for (const listener of listeners) listener(event);
+      return event;
+    },
+    get listenerCount() {
+      return listeners.size;
+    }
+  };
+}
+
+let target: ReturnType<typeof createFakeTarget>;
+
+function setup() {
+  __resetEscStackForTest();
+  target = createFakeTarget();
+  __setEscTargetForTest(target);
+}
+
+afterEach(() => {
+  __resetEscStackForTest();
+});
+
+describe('escStack', () => {
+  it('Esc достаётся верхнему входу, нижние не вызываются', () => {
+    setup();
+    const bottom = vi.fn();
+    const top = vi.fn();
+    pushEscHandler('bottom', bottom);
+    pushEscHandler('top', top);
+
+    target.dispatch('Escape');
+
+    expect(top).toHaveBeenCalledTimes(1);
+    expect(bottom).not.toHaveBeenCalled();
+  });
+
+  it('снятие входа не с вершины не ломает порядок — следующий Esc уходит новому верхнему', () => {
+    setup();
+    const bottom = vi.fn();
+    const middle = vi.fn();
+    const top = vi.fn();
+    const disposeBottom = pushEscHandler('bottom', bottom);
+    pushEscHandler('middle', middle);
+    pushEscHandler('top', top);
+
+    disposeBottom();
+    target.dispatch('Escape');
+
+    expect(top).toHaveBeenCalledTimes(1);
+    expect(middle).not.toHaveBeenCalled();
+    expect(bottom).not.toHaveBeenCalled();
+  });
+
+  it('пустой стек: слушатель снят, preventDefault не вызывается', () => {
+    setup();
+    const onEscape = vi.fn();
+    const dispose = pushEscHandler('only', onEscape);
+
+    dispose();
+
+    expect(target.listenerCount).toBe(0);
+    const event = target.dispatch('Escape');
+    expect(onEscape).not.toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('слушатель ставится ровно один раз на первой регистрации и снимается на последней', () => {
+    setup();
+    const disposeA = pushEscHandler('a', vi.fn());
+    expect(target.addEventListener).toHaveBeenCalledTimes(1);
+
+    pushEscHandler('b', vi.fn());
+    expect(target.addEventListener).toHaveBeenCalledTimes(1);
+
+    disposeA();
+    expect(target.removeEventListener).not.toHaveBeenCalled();
+  });
+
+  it('не-Escape клавиша не трогается вовсе — ни preventDefault, ни stopPropagation', () => {
+    setup();
+    const onEscape = vi.fn();
+    pushEscHandler('only', onEscape);
+
+    const event = target.dispatch('Enter');
+
+    expect(onEscape).not.toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.stopPropagation).not.toHaveBeenCalled();
+  });
+
+  it('двойной dispose одного входа идемпотентен (StrictMode)', () => {
+    setup();
+    const other = vi.fn();
+    pushEscHandler('other', other);
+    const dispose = pushEscHandler('doubled', vi.fn());
+
+    dispose();
+    dispose();
+
+    expect(target.listenerCount).toBe(1);
+    target.dispatch('Escape');
+    expect(other).toHaveBeenCalledTimes(1);
+  });
+
+  it('OS-автоповтор (repeat: true) не размативает стек — держим Esc, обработчик не вызывается второй раз', () => {
+    setup();
+    const bottom = vi.fn();
+    const top = vi.fn();
+    pushEscHandler('bottom', bottom);
+    pushEscHandler('top', top);
+
+    target.dispatch('Escape', true);
+
+    expect(top).not.toHaveBeenCalled();
+    expect(bottom).not.toHaveBeenCalled();
+  });
+
+  it('регистрация нового входа изнутри обработчика Esc не приводит к двойной обработке события', () => {
+    setup();
+    const opened = vi.fn();
+    const closeAndOpenConfirm = vi.fn(() => {
+      pushEscHandler('confirm', opened);
+    });
+    pushEscHandler('dialog', closeAndOpenConfirm);
+
+    target.dispatch('Escape');
+
+    expect(closeAndOpenConfirm).toHaveBeenCalledTimes(1);
+    expect(opened).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/src/stores/escStack.ts
+++ b/src/renderer/src/stores/escStack.ts
@@ -1,0 +1,107 @@
+/**
+ * Один стек закрытия по Esc вместо 17 самодельных обработчиков (ADR-0010,
+ * `docs/agent/adr/0010-esc-stack-not-overlay-module.md`). Плоский .ts-синглтон
+ * без React, по образцу соседних `composerBus.ts` и `terminalBuffer.ts`. Держит
+ * стек входов `(id, onEscape)` и один слушатель `keydown` на фазе capture:
+ * ставится при первой регистрации, снимается при последней.
+ *
+ * Обработка: клавиша не `Escape` — событие не трогается вовсе (остальной ввод
+ * терминала не задет). Стек пуст — слушателя нет, Esc уходит в сессию как
+ * сегодня. Стек непуст — `preventDefault()` + `stopPropagation()` и вызов
+ * `onEscape` только у верхнего входа.
+ */
+
+export interface KeyboardEventLike {
+  key: string;
+  repeat: boolean;
+  preventDefault(): void;
+  stopPropagation(): void;
+}
+
+interface EscTarget {
+  addEventListener(type: 'keydown', listener: (event: KeyboardEventLike) => void, options: { capture: true }): void;
+  removeEventListener(
+    type: 'keydown',
+    listener: (event: KeyboardEventLike) => void,
+    options: { capture: true }
+  ): void;
+}
+
+interface EscEntry {
+  id: string;
+  onEscape: () => void;
+}
+
+const stack: EscEntry[] = [];
+let testTarget: EscTarget | null = null;
+
+/** `window` берётся лениво — модуль должен импортироваться в node-окружении
+ *  vitest (`environment: 'node'`), где `window` не существует. */
+function getTarget(): EscTarget {
+  return testTarget ?? (window as unknown as EscTarget);
+}
+
+function handleKeyDown(event: KeyboardEventLike): void {
+  if (event.key !== 'Escape') return;
+  // OS-автоповтор при удержании клавиши шлёт несколько keydown с repeat=true
+  // до одного keyup — без этой проверки удержанный Esc мог бы размотать
+  // несколько уровней стека за одно физическое нажатие.
+  if (event.repeat) return;
+  const top = stack[stack.length - 1];
+  if (!top) return;
+  event.preventDefault();
+  event.stopPropagation();
+  // Верхний вход захвачен до вызова — если onEscape синхронно зарегистрирует
+  // новый вход (закрытие открывает ConfirmDialog), это событие всё равно
+  // обработано ровно один раз.
+  top.onEscape();
+}
+
+function ensureListenerInstalled(): void {
+  if (stack.length === 1) {
+    getTarget().addEventListener('keydown', handleKeyDown, { capture: true });
+  }
+}
+
+function ensureListenerRemoved(): void {
+  if (stack.length === 0) {
+    getTarget().removeEventListener('keydown', handleKeyDown, { capture: true });
+  }
+}
+
+/**
+ * Зарегистрировать вход стека — LIFO, верхний вход получает следующий Esc.
+ * Возвращает `dispose`, идемпотентный (React.StrictMode монтирует эффекты
+ * дважды — двойной `dispose` одного входа не должен ронять стек). Снятие входа
+ * не с вершины (диалог закрыт программно) не ломает порядок остальных.
+ */
+export function pushEscHandler(id: string, onEscape: () => void): () => void {
+  const entry: EscEntry = { id, onEscape };
+  stack.push(entry);
+  ensureListenerInstalled();
+
+  let disposed = false;
+  return function dispose(): void {
+    if (disposed) return;
+    disposed = true;
+    const index = stack.indexOf(entry);
+    if (index !== -1) stack.splice(index, 1);
+    ensureListenerRemoved();
+  };
+}
+
+/** Инъекция цели для тестов, по образцу `__setClientFactoryForTest` в `src/main/ssh`. */
+export function __setEscTargetForTest(target: EscTarget | null): void {
+  testTarget = target;
+}
+
+/** Сброс стека и тестовой цели между тестами. Снимает слушатель с текущей
+ *  цели, если стек был непуст, — иначе он остаётся висеть на брошенном
+ *  объекте, пока стек уже считается пустым. */
+export function __resetEscStackForTest(): void {
+  if (stack.length > 0) {
+    stack.length = 0;
+    getTarget().removeEventListener('keydown', handleKeyDown, { capture: true });
+  }
+  testTarget = null;
+}


### PR DESCRIPTION
## Что

PR-1 из `.scratch/esc-close-stack/spec.md` (решения приняты в `docs/agent/adr/0010-esc-stack-not-overlay-module.md`):

- `stores/escStack.ts` — плоский синглтон, LIFO-стек входов `(id, onEscape)`, один `keydown`-слушатель на фазе capture, ставится/снимается на переходах 0↔1↔0. Не-`Escape` клавиша не трогается вовсе. Guard на `event.repeat`, чтобы удержанный Esc не разматывал несколько уровней стека за одно физическое нажатие.
- `hooks/useEscapeClose.ts` — тонкая обвязка, колбэк в `ref` (перерегистрация не переставляет вход на вершину), опция `enabled`.
- `stores/escStack.test.ts` — 8 тестов, включая все 7 сценариев из спеки.

Ни к чему не подключено, поведение приложения не меняется.

## Проверено

- `npm run typecheck` — чисто
- `npm run lint` (на новых файлах) — чисто
- `npx vitest run` — 591/619 (28 предсуществующих падений в `hosts/`/`history/snippets` из-за ABI-блокера `better-sqlite3`↔Electron, не связаны с этим PR)
- `/code-review` (medium, 3 фоновых агента): 6 находок, 4 исправлены (repeat-guard, дублирование типа в тесте, ослабленная типизация фейковой цели через `as never`, пропуск `removeEventListener` в тестовом reset), 1 оставлена как есть, 1 отложена как риск для PR-2 (не баг текущего PR)

## Дальше

PR-2 — миграция всех 23 регистраций одним куском (см. спеку).

🤖 Generated with [Claude Code](https://claude.com/claude-code)