### PR TITLE
fix: block closing import dialogs while an import is applying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - **Esc while editing a history note no longer closes the whole History drawer.** The note input and the drawer each listened for Esc independently; cancelling the note also closed the drawer underneath it.
 - The SSH key wizard's Esc handling no longer depends on a hand-rolled `capture`/`stopPropagation` trick to avoid closing the connection form behind it — the shared stack orders it correctly by construction.
 - Four surfaces that already closed on a backdrop click — the JSON host import dialog, the "Возможности LucidSSH" guide, the multi-line paste preview, and the server dashboard — now also close on Esc.
+- The host import dialogs (JSON import and PuTTY/ssh_config/WinSCP import) can no longer be closed — by backdrop click, Esc, or the close button — while an import is actually being applied. Previously any of those closed the dialog immediately while the import kept running in the background, discarding the result (imported/skipped counts, errors) with no way to see it.
 
 - **The dangerous command guard now names every object a compound command destroys.** `rm -rf /var/www && rm -rf /etc` used to name only the first one, so you confirmed one deletion while two were about to happen. The dialog now lists all of them and asks you to type the name of one of them — picked at random among the most severe, so the expected answer can't be learned by habit and typed without reading. Commands with a single dangerous fragment are unchanged.
 

--- a/src/renderer/src/components/HostManager/ExternalImportDialog.tsx
+++ b/src/renderer/src/components/HostManager/ExternalImportDialog.tsx
@@ -84,7 +84,13 @@ export function ExternalImportDialog({ onClose }: { onClose: () => void }): JSX.
     else setResult(null); // ssh-config ждёт выбора файла
   }, [source, loadPutty, loadWinScp]);
 
-  useEscapeClose('external-import-dialog', onClose);
+  // Пока идёт применение импорта (busy), закрытие целиком запрещено — тот же
+  // разбор, что в ImportDialog (.scratch/import-dialog-busy-close/spec.md),
+  // применённый ко всем путям закрытия: бэкдропу, Esc и крестику в шапке.
+  const closeIfIdle = (): void => {
+    if (!busy) onClose();
+  };
+  useEscapeClose('external-import-dialog', closeIfIdle);
 
   const toggle = (i: number): void => {
     setSelected((prev) => {
@@ -123,7 +129,7 @@ export function ExternalImportDialog({ onClose }: { onClose: () => void }): JSX.
     </button>
   );
 
-  const backdrop = useBackdropClose(onClose);
+  const backdrop = useBackdropClose(closeIfIdle);
 
   return (
     <div
@@ -142,8 +148,9 @@ export function ExternalImportDialog({ onClose }: { onClose: () => void }): JSX.
           <button
             type="button"
             aria-label={t('common.close')}
-            onClick={onClose}
-            className="flex size-[24px] items-center justify-center rounded-[4px] text-text-dim hover:bg-bg-elevated-2 hover:text-text-strong"
+            disabled={busy}
+            onClick={closeIfIdle}
+            className="flex size-[24px] items-center justify-center rounded-[4px] text-text-dim hover:bg-bg-elevated-2 hover:text-text-strong disabled:cursor-not-allowed disabled:opacity-50"
           >
             <Icon name="close" size={15} />
           </button>

--- a/src/renderer/src/components/HostManager/ImportDialog.tsx
+++ b/src/renderer/src/components/HostManager/ImportDialog.tsx
@@ -35,8 +35,16 @@ export function ImportDialog({
       setBusy(false);
     }
   };
-  const backdrop = useBackdropClose(onClose);
-  useEscapeClose('import-dialog', onClose);
+  // Пока идёт применение импорта (busy), закрытие целиком запрещено — импорт
+  // короткий, и показать его до конца дешевле, чем заводить для него канал
+  // уведомлений о результате (.scratch/import-dialog-busy-close/spec.md).
+  // Действует на все пути закрытия разом — бэкдроп, Esc и «Отмена» ниже —
+  // иначе разрешить один и запретить другой было бы новой асимметрией.
+  const closeIfIdle = (): void => {
+    if (!busy) onClose();
+  };
+  const backdrop = useBackdropClose(closeIfIdle);
+  useEscapeClose('import-dialog', closeIfIdle);
 
   return (
     <div
@@ -81,8 +89,9 @@ export function ImportDialog({
             <>
               <button
                 type="button"
+                disabled={busy}
                 onClick={onClose}
-                className="h-[34px] rounded-[6px] bg-bg-tab-active px-4 text-[12.5px] text-text-body hover:text-text-strong"
+                className="h-[34px] rounded-[6px] bg-bg-tab-active px-4 text-[12.5px] text-text-body hover:text-text-strong disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {t('common.cancel')}
               </button>


### PR DESCRIPTION
Backdrop click, Esc, and the close/cancel button all now check `busy` before calling onClose in ImportDialog and ExternalImportDialog. Closing mid-import previously discarded the result silently while the import kept running in the background.