### PR TITLE
fix: reconcile local echo against the screen instead of a blind counter

### DIFF
--- a/src/renderer/src/components/Terminal/XtermView.tsx
+++ b/src/renderer/src/components/Terminal/XtermView.tsx
@@ -11,6 +11,7 @@ import type { AccessRiskPrompt, DangerousCommandPrompt } from '@shared/guard';
 import { getCurrentConfig } from '@/stores/config';
 import { attachTerminalWriter, dropTerminalBuffer } from '@/stores/terminalBuffer';
 import { Icon } from '@/components/common/Icon';
+import { reconcileEchoLine, redrawEchoLine } from './localEcho';
 
 /**
  * xterm.js-вью одной сессии (TERM-01, TERM-04, TERM-07).
@@ -83,6 +84,25 @@ function maskPasteIfAuthPrompt(sessionId: string, text: string): boolean {
 const commandBuffers = new Map<string, string>();
 const atPromptState = new Map<string, boolean>();
 const shellStateUnknown = new Map<string, boolean>();
+
+/**
+ * Эхо сверяется с экраном, а не считается по счётчику (ADR-0013,
+ * .scratch/local-echo-resize-desync/spec.md) — детали в localEcho.ts.
+ * echoStartCol — колонка, где Эхо начинается на своей экранной строке:
+ * записывается при переходе Набранной строки из пустой в непустую,
+ * переусваивается при расхождении со сверкой.
+ */
+const echoStartCol = new Map<string, number>();
+/** Отложенная сверка: doFit взводит таймер, следующая запись из PTY (колбэк
+ *  term.write) выполняет её раньше и снимает флаг сама; таймер — только
+ *  страховка на случай, если PTY вообще ничего не пришлёт (rows-only resize,
+ *  ADR-0005 не пускает его дальше renderer). handleCommandChar форсирует
+ *  сверку немедленно, если застаёт флаг — иначе Enter в окне между resize и
+ *  приходом данных отправил бы невидимую команду (ADR-0013 §4). */
+const reconcilePending = new Map<string, ReturnType<typeof setTimeout>>();
+/** Таймаут-страховка сверки (ADR-0013 §3) — цена безвредного таймера за то,
+ *  что rows-only resize не дублирует гейт ADR-0005 в renderer. */
+const RECONCILE_TIMEOUT_MS = 600;
 const dangerListeners = new Map<string, (prompt: DangerousCommandPrompt) => void>();
 const accessRiskListeners = new Map<string, (prompt: AccessRiskPrompt) => void>();
 const commandSentListeners = new Map<string, () => void>();
@@ -134,6 +154,58 @@ function ensureBreadcrumbSubscription(): void {
   window.lucidSSH.onIntegrationUnconfirmed((sessionId) => markIntegrationUnconfirmed(sessionId));
 }
 
+/** Отменяет отложенную сверку (таймер-страховку) — вызывается после того,
+ *  как сверка уже выполнилась (данными из PTY или самим таймером), и при
+ *  очистке состояния сессии. */
+function disarmReconcile(sessionId: string): void {
+  const timer = reconcilePending.get(sessionId);
+  if (timer !== undefined) clearTimeout(timer);
+  reconcilePending.delete(sessionId);
+}
+
+/** Взводит сверку после doFit (ADR-0013 §3–4): триггер — любой doFit, гейт
+ *  ADR-0005 по cols в renderer не дублируется. Настоящую сверку выполняет
+ *  либо колбэк term.write на следующих данных из PTY, либо этот таймер,
+ *  либо handleCommandChar, если пользователь набрал что-то раньше обоих. */
+function armReconcile(sessionId: string): void {
+  disarmReconcile(sessionId);
+  reconcilePending.set(
+    sessionId,
+    setTimeout(() => runReconcile(sessionId), RECONCILE_TIMEOUT_MS)
+  );
+}
+
+/** Сама сверка (ADR-0013 §3): дешёвая отсечка первой строкой — большинство
+ *  вызовов (почти каждый чанк вывода) на ней и заканчивается. `done` (если
+ *  дан) вызывается ПОСЛЕ того, как возможная перерисовка реально легла на
+ *  сетку — `term.write` у xterm асинхронный (WriteBuffer), поэтому
+ *  форсированный вызов из handleCommandChar (ADR-0013 §4) обязан дождаться
+ *  этого колбэка, прежде чем читать состояние терминала для самого ввода
+ *  (Backspace, история) — иначе он попадёт на ещё не применённую запись. */
+function runReconcile(sessionId: string, done?: () => void): void {
+  disarmReconcile(sessionId);
+  const term = cache.get(sessionId)?.term;
+  const text = isAtPrompt(sessionId) ? commandBuffers.get(sessionId) : undefined;
+  const startCol = echoStartCol.get(sessionId);
+  if (!term || !text || startCol === undefined) {
+    done?.();
+    return;
+  }
+  reconcileEchoLine(term, startCol, text, (newStartCol) => {
+    echoStartCol.set(sessionId, newStartCol);
+    done?.();
+  });
+}
+
+/** Записывает колонку старта Эха при переходе Набранной строки из пустой в
+ *  непустую — курсор в этот момент стоит там, где Эхо и начнётся, по
+ *  определению (ADR-0013 §2). Не привязываемся к markAtPrompt/finalizeLine:
+ *  привязка к промпту отвергнута, см. spec. */
+function markEchoStart(sessionId: string): void {
+  const term = cache.get(sessionId)?.term;
+  if (term) echoStartCol.set(sessionId, term.buffer.active.cursorX);
+}
+
 function clearSessionInputState(sessionId: string): void {
   commandBuffers.delete(sessionId);
   atPromptState.delete(sessionId);
@@ -141,16 +213,25 @@ function clearSessionInputState(sessionId: string): void {
   commandHistories.delete(sessionId);
   historyIndex.delete(sessionId);
   historyDraft.delete(sessionId);
+  echoStartCol.delete(sessionId);
+  disarmReconcile(sessionId);
 }
 
 /** Заменяет текущую набранную (но ещё не отправленную) строку на newText —
- *  стирает старое эхо посимвольным backspace и печатает новое. */
+ *  перерисовывает область Эха примитивом из localEcho.ts вместо посимвольного
+ *  backspace (тот не умел подниматься на строку выше при переносе — третий
+ *  дефект класса из ADR-0013). */
 function setBufferLine(sessionId: string, newText: string): void {
   const term = cache.get(sessionId)?.term;
   const old = commandBuffers.get(sessionId) ?? '';
-  if (old.length > 0) term?.write('\b \b'.repeat(old.length));
+  if (old.length > 0) {
+    const startCol = echoStartCol.get(sessionId) ?? 0;
+    if (term) redrawEchoLine(term, startCol, newText);
+  } else if (newText.length > 0) {
+    markEchoStart(sessionId);
+    term?.write(newText);
+  }
   commandBuffers.set(sessionId, newText);
-  if (newText) term?.write(newText);
 }
 
 function historyUp(sessionId: string): void {
@@ -189,6 +270,7 @@ function finalizeLine(sessionId: string): void {
   atPromptState.set(sessionId, false);
   historyIndex.delete(sessionId);
   historyDraft.delete(sessionId);
+  disarmReconcile(sessionId);
   if (sent.trim().length > 0) {
     const hist = commandHistories.get(sessionId) ?? [];
     if (hist[hist.length - 1] !== sent) hist.push(sent);
@@ -222,6 +304,22 @@ async function submitBufferedCommand(sessionId: string, command: string): Promis
 
 /** Обрабатывает один чанк ввода, пока сессия на промпте (см. коммент выше). */
 function handleCommandChar(sessionId: string, data: string): void {
+  // Окно между doFit и приходом данных из PTY (ADR-0013 §4): если сверка
+  // ещё не выполнилась, форсируем её немедленно по текущему состоянию
+  // экрана — иначе Enter в этом окне отправил бы невидимую команду, а
+  // сверка бы уже не помогла (finalizeLine отправляет раньше, чем данные
+  // могли бы прийти и её выполнить). Обработку самого чанка откладываем до
+  // колбэка: term.write асинхронный, если продолжить сразу же, Backspace
+  // или история из ЭТОГО ЖЕ чанка прочитали бы состояние терминала ДО того,
+  // как перерисовка сверки реально легла на сетку.
+  if (reconcilePending.has(sessionId)) {
+    runReconcile(sessionId, () => processCommandChunk(sessionId, data));
+    return;
+  }
+  processCommandChunk(sessionId, data);
+}
+
+function processCommandChunk(sessionId: string, data: string): void {
   // Стрелки вверх/вниз — локальная история (см. commandHistories выше).
   if (data === '\x1b[A') {
     historyUp(sessionId);
@@ -255,13 +353,20 @@ function handleCommandChar(sessionId: string, data: string): void {
     if (code === 0x7f || code === 0x08) {
       const buf = commandBuffers.get(sessionId) ?? '';
       if (buf.length > 0) {
-        commandBuffers.set(sessionId, buf.slice(0, -1));
-        term?.write('\b \b');
+        const newBuf = buf.slice(0, -1);
+        commandBuffers.set(sessionId, newBuf);
+        // Перерисовка вместо слепого '\b \b' (ADR-0013) — на экране может
+        // быть уже не то, что мы думаем, стирать вслепую значит рисковать
+        // съесть приглашение.
+        const startCol = echoStartCol.get(sessionId) ?? 0;
+        if (term) redrawEchoLine(term, startCol, newBuf);
       }
       continue;
     }
     if (code >= 0x20 || ch === '\t') {
-      commandBuffers.set(sessionId, (commandBuffers.get(sessionId) ?? '') + ch);
+      const buf = commandBuffers.get(sessionId) ?? '';
+      if (buf.length === 0) markEchoStart(sessionId);
+      commandBuffers.set(sessionId, buf + ch);
       term?.write(ch);
     }
     // Прочие управляющие символы игнорируются.
@@ -350,7 +455,9 @@ export function pasteText(sessionId: string, text: string): void {
  */
 export function insertText(sessionId: string, text: string): void {
   if (isAtPrompt(sessionId)) {
-    commandBuffers.set(sessionId, (commandBuffers.get(sessionId) ?? '') + text);
+    const buf = commandBuffers.get(sessionId) ?? '';
+    if (buf.length === 0 && text.length > 0) markEchoStart(sessionId);
+    commandBuffers.set(sessionId, buf + text);
     cache.get(sessionId)?.term.write(text);
   } else {
     pasteText(sessionId, text);
@@ -467,8 +574,13 @@ function createTerminal(sessionId: string): Cached {
     }
   });
 
-  // Вывод сервера — из буфера (накопленное до монтирования + живой поток)
-  attachTerminalWriter(sessionId, (data) => term.write(data));
+  // Вывод сервера — из буфера (накопленное до монтирования + живой поток).
+  // Колбэк term.write вызывается, когда чанк разобран и лёг на сетку — это
+  // и есть единственная точка сверки Эха с экраном (ADR-0013 §3), таймер
+  // не нужен.
+  attachTerminalWriter(sessionId, (data) => {
+    term.write(data, () => runReconcile(sessionId));
+  });
 
   const container = document.createElement('div');
   container.className = 'h-full w-full';
@@ -577,6 +689,10 @@ export function XtermView({
       try {
         cached!.fit.fit();
         window.lucidSSH.resizeSession(sessionId, cached!.term.cols, cached!.term.rows);
+        // Триггер сверки — любой doFit, без уточнений (ADR-0013 §3): гейт по
+        // cols из ADR-0005 не дублируется здесь, сверке всё равно, что было
+        // причиной расхождения.
+        armReconcile(sessionId);
       } catch {
         /* контейнер ещё без размера */
       }

--- a/src/renderer/src/components/Terminal/localEcho.test.ts
+++ b/src/renderer/src/components/Terminal/localEcho.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { buildRedrawSequence, echoRowRanges, findEchoStartRow, reconcile } from './localEcho';
+
+/**
+ * Обязательное покрытие чистого ядра localEcho.ts (CLAUDE.md §10, ADR-0013).
+ * Никакого @xterm/headless — только простые данные (environment: 'node').
+ */
+
+describe('findEchoStartRow — перенос строки', () => {
+  it('Эхо длиннее cols: поднимается на нужное число строк по цепочке isWrapped', () => {
+    // Строки 5,6,7 — перенос друг друга (одно логическое Эхо на 3 экранных
+    // строки), строка 4 — начало (приглашение), 8 — соседняя команда сверху,
+    // никак не участвует.
+    const wrapped = new Set([5, 6, 7]);
+    const isWrapped = (row: number): boolean => wrapped.has(row);
+    expect(findEchoStartRow(isWrapped, 7)).toBe(4);
+    // Перенос строки при стирании (третий дефект класса, spec §"Диагноз шире
+    // исходного отчёта") чинится тем же примитивом — buildRedrawSequence
+    // получает верное linesUp = cursorRow - startRow.
+    expect(buildRedrawSequence(7 - 4, 4, 'x')).toContain('\x1b[3A');
+  });
+
+  it('Эхо не переносилось: строка старта совпадает со строкой курсора', () => {
+    expect(findEchoStartRow(() => false, 12)).toBe(12);
+  });
+
+  it('не поднимается выше строки 0, даже если она тоже помечена isWrapped', () => {
+    expect(findEchoStartRow(() => true, 0)).toBe(0);
+  });
+
+  it('широкие символы (CJK) и табы: считать по длине текста было бы неверно — ' +
+    'isWrapped даёт точный ответ независимо от того, что реально заняло ячейки', () => {
+    // cols=10: приглашение с CJK-символом (2 ячейки) + Tab (прыжок до
+    // табстопа, не одна ячейка) заполняют ровно 10 колонок первой строки —
+    // JS-строка "ëêç" по факту занимает МЕНЬШЕ 10 символов, чем 10 ячеек,
+    // поэтому наивная арифметика "startCol + text.length <= cols" сочла бы,
+    // что переноса нет. Настоящий терминал перенёс — isWrapped(1) === true —
+    // и findEchoStartRow верит этому факту, а не счёту символов.
+    const naiveGuessNoWrap = 3 + 'ab'.length <= 10; // 3 колонки "занято" по символам, а не по ячейкам
+    expect(naiveGuessNoWrap).toBe(true); // наивная арифметика ошиблась бы
+    const isWrapped = (row: number): boolean => row === 1;
+    expect(findEchoStartRow(isWrapped, 1)).toBe(0); // а сверка по isWrapped — нет
+  });
+});
+
+describe('echoRowRanges — арифметика колоночных диапазонов', () => {
+  it('Эхо на одной строке — один диапазон от startCol до курсора', () => {
+    expect(echoRowRanges(4, 6, 4, 10, 80)).toEqual([{ row: 4, from: 6, to: 10 }]);
+  });
+
+  it('Эхо, перенесённое на 3 строки — первая до конца, средняя целиком, последняя от начала', () => {
+    expect(echoRowRanges(4, 76, 6, 5, 80)).toEqual([
+      { row: 4, from: 76, to: 80 },
+      { row: 5, from: 0, to: 80 },
+      { row: 6, from: 0, to: 5 }
+    ]);
+  });
+});
+
+describe('reconcile — три исхода', () => {
+  it('текст на месте → no-op, колонка старта не меняется', () => {
+    const r = reconcile('abcd', 'abcd', 5, 9);
+    expect(r).toEqual({ matched: true, startCol: 5 });
+    expect(r.redrawSequence).toBeUndefined();
+  });
+
+  it('текста нет → перерисовать от текущего курсора, колонка переусвоена', () => {
+    const r = reconcile('', 'abcd', 5, 4);
+    expect(r.matched).toBe(false);
+    expect(r.startCol).toBe(4); // переусвоена от cursorCol, не от старого startCol=5
+    expect(r.redrawSequence).toBe(buildRedrawSequence(0, 4, 'abcd'));
+  });
+
+  it('приглашение уехало ниже (fish-подобный случай) → перерисовка от нового курсора', () => {
+    // Курсор на другой строке, readline только что напечатал пустое
+    // приглашение — на его месте не может быть Набранной строки, значит
+    // расхождение и здесь. Перерисовка не трогает то, что осталось выше
+    // (buildRedrawSequence с linesUp=0 пишет строго от текущей позиции).
+    const r = reconcile('', 'abcd', 5, 0);
+    expect(r.matched).toBe(false);
+    expect(r.startCol).toBe(0);
+    expect(r.redrawSequence).toBe(buildRedrawSequence(0, 0, 'abcd'));
+  });
+
+  it('идемпотентность: повторный вызов после перерисовки не даёт удвоения', () => {
+    const first = reconcile('', 'abcd', 5, 4);
+    expect(first.matched).toBe(false);
+    // Экран теперь показывает то, что первый вызов записал.
+    const second = reconcile('abcd', 'abcd', first.startCol, 8);
+    expect(second).toEqual({ matched: true, startCol: first.startCol });
+    expect(second.redrawSequence).toBeUndefined();
+  });
+});
+
+describe('buildRedrawSequence — сборка escape-последовательности', () => {
+  it('не двигается влево от startCol=0 и вверх, если курсор уже на строке старта', () => {
+    const seq = buildRedrawSequence(0, 0, 'abcd');
+    expect(seq).toBe('\r\x1b[Jabcd');
+  });
+
+  it('поднимается на linesUp строк и вправо на startCol колонок перед стиранием', () => {
+    const seq = buildRedrawSequence(2, 4, 'ab');
+    expect(seq).toBe('\x1b[2A\r\x1b[4C\x1b[Jab');
+  });
+});

--- a/src/renderer/src/components/Terminal/localEcho.ts
+++ b/src/renderer/src/components/Terminal/localEcho.ts
@@ -1,0 +1,201 @@
+import type { Terminal } from '@xterm/xterm';
+
+/**
+ * Эхо сверяется с содержимым экрана, а не считается по счётчику (ADR-0013,
+ * `.scratch/local-echo-resize-desync/spec.md`). Раньше стирание делалось
+ * вслепую — `'\b \b'.repeat(n)` по счётчику из Набранной строки, без сверки
+ * с тем, что на экране на самом деле. Экран уезжает из-под этого счётчика
+ * от чего угодно, что пишет в терминал помимо нас (resize → readline
+ * перерисовывает строку приглашения на SIGWINCH; вклинившийся вывод с
+ * сервера — тоже) — xterm держит содержимое сетки и отдаёт его публичным
+ * API, поэтому «текст на экране или нет» можно не гадать по сигналам
+ * шелла, можно посмотреть.
+ *
+ * Чистое ядро ниже (арифметика позиций, сравнение, сборка
+ * escape-последовательностей) не знает про DOM и про xterm — тестируется в
+ * обычном node-окружении. Тонкий адаптер под ним читает/пишет настоящий
+ * `Terminal`; XtermView.tsx использует только адаптерные функции
+ * (`redrawEchoLine`, `reconcileEchoLine`).
+ */
+
+// ---------------------------------------------------------------------------
+// Чистое ядро — без DOM и без xterm (vitest.config.ts: environment 'node').
+// ---------------------------------------------------------------------------
+
+/**
+ * Поднимается от курсора вверх по цепочке «перенесённых» строк (isWrapped) —
+ * находит визуальную строку, где на самом деле начинается текущая логическая
+ * строка терминала (приглашение + Эхо). Не считает символы: сколько ячеек
+ * реально заняло Эхо, зависит от табов и широких (CJK, 2 ячейки) символов —
+ * посчитать это арифметикой по длине строки нельзя, а isWrapped уже посчитан
+ * правильно самим xterm в момент записи. Это и есть смягчение из ADR-0013:
+ * подъём по isWrapped вместо чистой арифметики по длине текста.
+ *
+ * @param isWrapped Признак «эта строка — перенос предыдущей» для абсолютного
+ *   индекса строки буфера (адаптер передаёт
+ *   `term.buffer.active.getLine(row)?.isWrapped`).
+ * @param cursorRow Абсолютный индекс строки, где сейчас курсор.
+ */
+export function findEchoStartRow(isWrapped: (row: number) => boolean, cursorRow: number): number {
+  let row = cursorRow;
+  while (row > 0 && isWrapped(row)) row -= 1;
+  return row;
+}
+
+/**
+ * Диапазон колонок на одной строке экрана. Адаптер читает/стирает его через
+ * `translateToString(false, from, to)` — колоночными границами, а не
+ * индексом JS-строки: иначе широкие символы (CJK, 2 ячейки) не совпадут с
+ * позицией курсора (одна ячейка ширины 2 — это один код в JS-строке, но две
+ * колонки на экране).
+ */
+export interface RowRange {
+  row: number;
+  from: number;
+  to: number;
+}
+
+/**
+ * Диапазоны колонок, которые Эхо занимает на экране между (startRow,
+ * startCol) и (cursorRow, cursorCol). Если Эхо не переносилось — диапазон
+ * один; если переносилось (длиннее cols) — первая строка от startCol до
+ * конца, средние строки целиком, последняя строка от начала до курсора.
+ */
+export function echoRowRanges(
+  startRow: number,
+  startCol: number,
+  cursorRow: number,
+  cursorCol: number,
+  cols: number
+): RowRange[] {
+  if (startRow === cursorRow) return [{ row: startRow, from: startCol, to: cursorCol }];
+  const ranges: RowRange[] = [{ row: startRow, from: startCol, to: cols }];
+  for (let row = startRow + 1; row < cursorRow; row += 1) ranges.push({ row, from: 0, to: cols });
+  ranges.push({ row: cursorRow, from: 0, to: cursorCol });
+  return ranges;
+}
+
+/**
+ * Escape-последовательность примитива «перерисовать область Эха»: вернуть
+ * курсор к старту относительными перемещениями (`\x1b[<n>A` — вверх на n
+ * строк, `\r` — в начало строки, `\x1b[<c>C` — вправо на c колонок), стереть
+ * до конца экрана (`\x1b[J`), напечатать текст. Левее startCol примитив не
+ * ходит НИКОГДА — неприкосновенность приглашения (ADR-0013) не отдельная
+ * проверка, а прямое следствие того, что тут не с чем сравнивать: только
+ * вправо от нуля.
+ */
+export function buildRedrawSequence(linesUp: number, startCol: number, text: string): string {
+  let seq = '';
+  if (linesUp > 0) seq += `\x1b[${linesUp}A`;
+  seq += '\r';
+  if (startCol > 0) seq += `\x1b[${startCol}C`;
+  seq += '\x1b[J';
+  return seq + text;
+}
+
+export interface ReconcileResult {
+  matched: boolean;
+  /** Новая колонка старта Эха: не меняется при совпадении, переусваивается
+   *  от текущего курсора при расхождении — после перерисовки readline
+   *  ставит курсор сразу за приглашением (его буфер пуст), значит cursorCol
+   *  в этот момент и есть корректная новая колонка старта (ADR-0013 §2). */
+  startCol: number;
+  /** Присутствует, только если !matched — что нужно записать в терминал. */
+  redrawSequence?: string;
+}
+
+/**
+ * Сверка Набранной строки с прочитанным содержимым экрана. Три исхода:
+ * текст на месте — no-op (matched=true, startCol не меняется); текста нет —
+ * перерисовать от текущего курсора; приглашение уехало в другое место
+ * (fish-подобный случай, readline напечатал приглашение ниже) — тот же
+ * случай «текста нет» на новом месте, перерисовка тоже от текущего курсора,
+ * старая копия остаётся выше как обычный след в истории (перерисовка не
+ * трогает ничего выше себя). Идемпотентна: повторный вызов с actualText,
+ * уже равным expectedText (после того как адаптер записал redrawSequence),
+ * снова даст matched=true и ничего не напечатает.
+ */
+export function reconcile(
+  actualText: string,
+  expectedText: string,
+  oldStartCol: number,
+  cursorCol: number
+): ReconcileResult {
+  if (actualText === expectedText) return { matched: true, startCol: oldStartCol };
+  return {
+    matched: false,
+    startCol: cursorCol,
+    redrawSequence: buildRedrawSequence(0, cursorCol, expectedText)
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Адаптер — тонкий слой поверх настоящего xterm.Terminal. @xterm/headless не
+// подключаем (не нужен зависимостью, см. spec «Чего НЕ делаем») — вся
+// арифметика уже проверена в ядре выше, здесь только чтение/запись.
+// ---------------------------------------------------------------------------
+
+function cursorAbsRow(term: Terminal): number {
+  const buf = term.buffer.active;
+  return buf.baseY + buf.cursorY;
+}
+
+function findEchoStartRowOnTerm(term: Terminal, cursorRow: number): number {
+  return findEchoStartRow((row) => term.buffer.active.getLine(row)?.isWrapped ?? false, cursorRow);
+}
+
+function readEchoFromScreen(term: Terminal, startCol: number): { text: string; cursorCol: number } {
+  const cursorRow = cursorAbsRow(term);
+  const cursorCol = term.buffer.active.cursorX;
+  const startRow = findEchoStartRowOnTerm(term, cursorRow);
+  const ranges = echoRowRanges(startRow, startCol, cursorRow, cursorCol, term.cols);
+  const text = ranges
+    .map((r) => term.buffer.active.getLine(r.row)?.translateToString(false, r.from, r.to) ?? '')
+    .join('');
+  return { text, cursorCol };
+}
+
+/**
+ * Примитив «перерисовать область Эха» на реальном терминале — общий для
+ * Backspace и подстановки строки из локальной истории (стрелки ↑/↓): оба
+ * доверяют переданному startCol, никакого сравнения с экраном не делают.
+ * Перенос строки при стирании чинится тем же примитивом (третий дефект
+ * класса из spec) — `linesUp` считается через findEchoStartRowOnTerm, а не
+ * предполагается равным 0.
+ */
+export function redrawEchoLine(term: Terminal, startCol: number, text: string): void {
+  const cursorRow = cursorAbsRow(term);
+  const startRow = findEchoStartRowOnTerm(term, cursorRow);
+  term.write(buildRedrawSequence(cursorRow - startRow, startCol, text));
+}
+
+/**
+ * Сверка Набранной строки с экраном (ADR-0013 §3): читает ячейки перед
+ * курсором на ширину expectedText и сравнивает. Совпало — ничего не пишет;
+ * не совпало — перерисовывает. В обоих случаях `done` получает актуальную
+ * колонку старта — вызывающий обязан сохранить её как новый startCol
+ * (переусвоение происходит здесь, не на стороне вызывающего).
+ *
+ * Асинхронная по необходимости, не по стилю: `term.write` у xterm сам
+ * асинхронный (WriteBuffer ставит запись в очередь и парсит её позже — тем
+ * же callback-приёмом читает состояние сетки XtermView.tsx на самих данных
+ * из PTY, см. ADR-0013 §3). Если звать `done` сразу же после `term.write(...)`
+ * без ожидания её колбэка, любой код, который читает `term.buffer.active`
+ * дальше в ТОМ ЖЕ синхронном тике (например следующий Backspace того же
+ * чанка ввода), увидит состояние ДО перерисовки — не после. `done`
+ * вызывается синхронно только тогда, когда писать было нечего (matched).
+ */
+export function reconcileEchoLine(
+  term: Terminal,
+  startCol: number,
+  expectedText: string,
+  done: (newStartCol: number) => void
+): void {
+  const { text, cursorCol } = readEchoFromScreen(term, startCol);
+  const result = reconcile(text, expectedText, startCol, cursorCol);
+  if (result.matched || !result.redrawSequence) {
+    done(result.startCol);
+    return;
+  }
+  term.write(result.redrawSequence, () => done(result.startCol));
+}


### PR DESCRIPTION
## Summary

Local echo on the prompt (GUARD-04) was erased with `'\b \b'.repeat(n)` by a
character counter, with no check against what was actually on screen. The
screen slides out from under that counter on any real PTY resize (readline
redraws the prompt line on SIGWINCH with an empty buffer) or on output
arriving mid-type — Backspace then eats the prompt, and Enter can send a
command the user never saw.

See [ADR-0013](docs/agent/adr/0013-local-echo-reconciled-against-screen.md)
for the full decision writeup.

## Changes

- `localEcho.ts` (new): pure core — row/column arithmetic via
  `isWrapped`-climbing (robust to tabs and wide CJK chars), escape-sequence
  assembly, a 3-outcome reconcile decision — plus a thin xterm adapter.
- `XtermView.tsx`: one primitive, "redraw the echo area", replaces the blind
  backspace at all three call sites (Backspace, history substitution,
  reconciliation) and fixes line-wrap erasure as a side effect.
  Reconciliation runs in `term.write`'s completion callback on every PTY
  chunk while at prompt with a non-empty buffer, and is forced (waiting for
  its own write to actually apply, since xterm's `WriteBuffer` is async)
  before processing new input if a resize-triggered reconciliation is still
  pending — closing the network-latency window where Enter could otherwise
  submit an invisible command.
- `localEcho.test.ts` (new): 12 tests for the pure core.

## Testing

- `npm run typecheck` — clean
- `npm run lint` — clean (only pre-existing unrelated warnings)
- `npm run rebuild:test && npx vitest run` — 657/657 passed, `npm run rebuild:app` after
- Live verification (see `.scratch/local-echo-resize-desync/spec.md`): base
  repro, rows-only resize, wrapped-command backspace, and interleaved
  server output all confirmed; the Enter-in-the-network-window race is
  guaranteed by call-sequencing in the code but not reproducible by hand
  (human reaction time exceeds local network latency); zsh sanity run
  skipped for lack of a host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
